### PR TITLE
Add widefat class to text area to help with sizing

### DIFF
--- a/classes/customize-control-textarea.php
+++ b/classes/customize-control-textarea.php
@@ -34,7 +34,7 @@ class Hybrid_Customize_Control_Textarea extends WP_Customize_Control {
 		<label>
 			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
 			<div class="customize-control-content">
-				<textarea cols="45" rows="5" <?php $this->link(); ?>><?php echo esc_textarea( $this->value() ); ?></textarea>
+				<textarea cols="45" rows="5" class="widefat" <?php $this->link(); ?>><?php echo esc_textarea( $this->value() ); ?></textarea>
 			</div>
 		</label>
 	<?php }


### PR DESCRIPTION
Adds 'widefat' class to the customizer textarea to help keep the size of the textarea within the confines of the sidebar.
