### PR TITLE
Set the correct suffix to the main stylesheet

### DIFF
--- a/functions/styles.php
+++ b/functions/styles.php
@@ -145,8 +145,8 @@ function hybrid_min_stylesheet_uri( $stylesheet_uri, $stylesheet_dir_uri ) {
 	/* Remove the stylesheet directory URI from the file name. */
 	$stylesheet = str_replace( trailingslashit( $stylesheet_dir_uri ), '', $stylesheet_uri );
 
-	/* Change the stylesheet name to 'style.dev.css'. */
-	$stylesheet = str_replace( '.css', '.min.css', $stylesheet );
+	/* Change the stylesheet name to 'style.min.css'. */
+	$stylesheet = str_replace( '.css', "{$suffix}.css", $stylesheet );
 
 	/* If the stylesheet exists in the stylesheet directory, set the stylesheet URI to the dev stylesheet. */
 	if ( file_exists( trailingslashit( get_stylesheet_directory() ) . $stylesheet ) )


### PR DESCRIPTION
The suffix is already defined to be style.min.css if SCRIPT_DEBUG is turned off. We just needed to add this conditional suffix to the name of the stylesheet itself.
