### PR TITLE
Small fix for a stray "\" in the loop_pagination output

### DIFF
--- a/extensions/loop-pagination.php
+++ b/extensions/loop-pagination.php
@@ -96,7 +96,7 @@ function loop_pagination( $args = array() ) {
 
 	/* Remove 'page/1' from the entire output since it's not needed. */
 	$page_links = str_replace( array( "?paged=1'", "&#038;paged=1'", "/{$pagination_base}/1'", "/{$pagination_base}/1/'" ), '\'', $page_links );
-	$page_links = str_replace( array( '?paged=1"', '&#038;paged=1"', "/{$pagination_base}/1\"", "/{$pagination_base}/1/\"" ), '\"', $page_links );
+	$page_links = str_replace( array( '?paged=1"', '&#038;paged=1"', "/{$pagination_base}/1\"", "/{$pagination_base}/1/\"" ), '"', $page_links );
 
 	/* Wrap the paginated links with the $before and $after elements. */
 	$page_links = $args['before'] . $page_links . $args['after'];


### PR DESCRIPTION
As indicated in title I think a small fix might be needed in loop_pagination to fix a stray "\" in the output.

https://github.com/FindingSimple/hybrid-core/commit/9747c411438aa67887c7392fdc5d9b66c651f2d8
