### PR TITLE
Composer and Bower support require fix

### DIFF
--- a/hybrid.php
+++ b/hybrid.php
@@ -120,7 +120,7 @@ if ( !class_exists( 'Hybrid' ) ) {
 
 			/* Sets the path to the core framework directory. */
 			if ( !defined( 'HYBRID_DIR' ) )
-				define( 'HYBRID_DIR', trailingslashit( THEME_DIR ) . basename( dirname( __FILE__ ) ) );
+				define( 'HYBRID_DIR', trailingslashit( dirname( __FILE__ ) ) );
 
 			/* Sets the path to the core framework directory URI. */
 			if ( !defined( 'HYBRID_URI' ) )


### PR DESCRIPTION
- This makes it where you can put hybrid-core in any folder
- As of now if you use Bower or Composer it will not load the core correctly due to trying to put it in hybrid-core/ at the directory root with the require_once of the core
- Simple, one-line fix

Completely fixes the problem found in #32 that @Rarst found
