### PR TITLE
(potential) alternative fix for loop pagination issue

### DIFF
--- a/extensions/loop-pagination.php
+++ b/extensions/loop-pagination.php
@@ -69,8 +69,10 @@ function loop_pagination( $args = array() ) {
 	);
 
 	/* Add the $base argument to the array if the user is using permalinks. */
-	if ( $wp_rewrite->using_permalinks() && !is_search() )
-		$defaults['base'] = user_trailingslashit( trailingslashit( get_pagenum_link() ) . "{$pagination_base}/%#%" );
+	if ( $wp_rewrite->using_permalinks() && !is_search() ) {
+		$big = 999999999;
+		$defaults['base'] = str_replace( $big, '%#%', get_pagenum_link($big) );
+	}
 
 	/* Allow developers to overwrite the arguments with a filter. */
 	$args = apply_filters( 'loop_pagination_args', $args );


### PR DESCRIPTION
(potential) alternative fix for loop pagination issue described here: https://github.com/justintadlock/hybrid-core/issues/56

Based on get_pagenum_link() usage/implementation described here:

http://www.kevinleary.net/wordpress-pagination-paginate_links/ 

and in the codex at

http://codex.wordpress.org/Function_Reference/paginate_links#Examples

Worked in my situation for pagination pretty permalink urls that had ?utm=xxx on the end e.g. http://test.com/category/nameofcat/?utm=example which resulted in incorrect pagination links like:
- http://test.com/category/nameofcat/?utm=example/page/2/
- http://test.com/category/nameofcat/?utm=example/page/3/
- http://test.com/category/nameofcat/?utm=example/page/4/

Applying the change resulted in correct urls like:
- http://test.com/category/nameofcat/page/2/?utm=example
- http://test.com/category/nameofcat/page/3/?utm=example
- http://test.com/category/nameofcat/page/4/?utm=example
