### PR TITLE
refactor: tweak HC 'path'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name"        : "justintadlock/hybrid-core",
+	"name"        : "themehybrid/hybrid-core",
 	"description" : "Hybrid Core: A theme framework for developing modern WordPress themes.",
 	"keywords"    : [ "wordpress" ],
 	"homepage"    : "https://themehybrid.com/hybrid-core",
@@ -26,8 +26,10 @@
 	},
 	"require"     : {
 		"php" : ">=5.6",
-		"themehybrid/hybrid-contracts": "^1.0.0",
-		"themehybrid/hybrid-tools": "^1.0.0"
+	"require"     : {
+		"php" : ">=5.6",
+		"themehybrid/hybrid-contracts" : "dev-master",
+		"themehybrid/hybrid-tools" : "dev-master"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,5 @@
 		"php" : ">=5.6",
 		"themehybrid/hybrid-contracts" : "dev-master",
 		"themehybrid/hybrid-tools" : "dev-master"
-	},
-	"config": {
-		"optimize-autoloader": true,
-		"sort-packages": true
-	},
-	"minimum-stability": "dev",
-	"prefer-stable": true
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,6 @@
 	},
 	"require"     : {
 		"php" : ">=5.6",
-	"require"     : {
-		"php" : ">=5.6",
 		"themehybrid/hybrid-contracts" : "dev-master",
 		"themehybrid/hybrid-tools" : "dev-master"
 	},

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -98,7 +98,12 @@ class Application extends Container implements ApplicationContract, Bootable {
 		$this->instance( 'app', $this );
 
 		// Adds the directory path for the framework.
-		$this->instance( 'path', untrailingslashit( HYBRID_DIR  ) );
+		// This shouldn't need changing
+		// unless doing something really out there or just for clarity.
+		if ( ! $this->has( 'path' ) ) {
+			// Adds the directory path for the framework.
+			$this->instance( 'path', untrailingslashit( HYBRID_DIR ) );
+		}
 
 		// Add the version for the framework.
 		$this->instance( 'version', static::VERSION );

--- a/src/bootstrap-hybrid.php
+++ b/src/bootstrap-hybrid.php
@@ -12,8 +12,13 @@
  * @license   http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
 
-# Define the directory path to the framework. This shouldn't need changing
-# unless doing something really out there or just for clarity.
+/**
+ * Define the directory path to the framework. This shouldn't need changing
+ * unless doing something really out there or just for clarity.
+ *
+ * @deprecated 6.0
+ * @deprecated Use $themeslug->instance( 'path', '/path/to/hybrid-core );
+ */
 if ( ! defined( 'HYBRID_DIR' ) ) {
 
 	define( 'HYBRID_DIR', __DIR__ );


### PR DESCRIPTION
- Deprecated HYBRID_DIR
- Suggests setting the directory path for the framework directly, instead of utilizing the HYBRID_DIR constant.


related issue: https://github.com/themehybrid/hybrid-core/issues/181