### PR TITLE
tweak: adding conditional check around class_alias to avoid warnings

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -258,7 +258,9 @@ class Application extends Container implements ApplicationContract, Bootable {
 	 */
 	protected function registerProxy( $class, $alias ) {
 
-		class_alias( $class, $alias );
+		if ( ! class_exists( $alias ) ) {
+			class_alias( $class, $alias );
+		}
 
 		$this->registered_proxies[] = $alias;
 	}


### PR DESCRIPTION
'\Hybrid\App' is already declared warning is thrown, when HC is being used in theme & plugin at same time, so to supress that warning, adding conditional check before setting class alias.

old commit ref: https://github.com/saas786/hybrid-core/commit/ba5ec87