### PR TITLE
feat: sync container with Laravel container v9.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,10 @@
 		]
 	},
 	"require"     : {
-                "php" : ">=7.0",
-		"themehybrid/hybrid-contracts" : "^1.0"
+		"php" : "^7.4|^8.0",
+		"themehybrid/hybrid-contracts" : "^1.0",
+		"psr/container": "1.0.0",
+		"symfony/polyfill-php80": "^1.25.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true

--- a/src/Container/BoundMethod.php
+++ b/src/Container/BoundMethod.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Hybrid\Container;
+
+use Closure;
+use Hybrid\Contracts\Container\BindingResolutionException;
+use Hybrid\Util;
+use InvalidArgumentException;
+use ReflectionFunction;
+use ReflectionMethod;
+
+class BoundMethod {
+	/**
+	 * Call the given Closure / class@method and inject its dependencies.
+	 *
+	 * @param Container $container
+	 * @param  callable|string  $callback
+	 * @param  array  $parameters
+	 * @param  string|null  $defaultMethod
+	 * @return mixed
+	 *
+	 * @throws \ReflectionException
+	 * @throws \InvalidArgumentException
+	 */
+	public static function call( $container, $callback, array $parameters = [], $defaultMethod = null ) {
+		if ( is_string( $callback ) && ! $defaultMethod && method_exists( $callback, '__invoke') ) {
+			$defaultMethod = '__invoke';
+		}
+
+		if ( static::isCallableWithAtSign( $callback ) || $defaultMethod ) {
+			return static::callClass( $container, $callback, $parameters, $defaultMethod );
+		}
+
+		return static::callBoundMethod( $container, $callback, function () use ( $container, $callback, $parameters ) {
+			return $callback( ...array_values( static::getMethodDependencies( $container, $callback, $parameters ) ) );
+		} );
+	}
+
+	/**
+	 * Call a string reference to a class using Class@method syntax.
+	 *
+	 * @param Container $container
+	 * @param  string  $target
+	 * @param  array  $parameters
+	 * @param  string|null  $defaultMethod
+	 * @return mixed
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	protected static function callClass( $container, $target, array $parameters = [], $defaultMethod = null ) {
+		$segments = explode( '@', $target );
+
+		// We will assume an @ sign is used to delimit the class name from the method
+		// name. We will split on this @ sign and then build a callable array that
+		// we can pass right back into the "call" method for dependency binding.
+		$method = count( $segments ) === 2
+			? $segments[1] : $defaultMethod;
+
+		if ( is_null( $method ) ) {
+			throw new InvalidArgumentException( 'Method not provided.' );
+		}
+
+		return static::call(
+			$container, [ $container->make( $segments[0] ), $method ], $parameters
+		);
+	}
+
+	/**
+	 * Call a method that has been bound to the container.
+	 *
+	 * @param Container $container
+	 * @param  callable  $callback
+	 * @param  mixed  $default
+	 * @return mixed
+	 */
+	protected static function callBoundMethod( $container, $callback, $default ) {
+		if ( ! is_array( $callback ) ) {
+			return Util::unwrapIfClosure( $default );
+		}
+
+		// Here we need to turn the array callable into a Class@method string we can use to
+		// examine the container and see if there are any method bindings for this given
+		// method. If there are, we can call this method binding callback immediately.
+		$method = static::normalizeMethod( $callback );
+
+		if ( $container->hasMethodBinding( $method ) ) {
+			return $container->callMethodBinding( $method, $callback[0] );
+		}
+
+		return Util::unwrapIfClosure( $default );
+	}
+
+	/**
+	 * Normalize the given callback into a Class@method string.
+	 *
+	 * @param  callable  $callback
+	 * @return string
+	 */
+	protected static function normalizeMethod( $callback ) {
+		$class = is_string( $callback[0] ) ? $callback[0] : get_class( $callback[0] );
+
+		return "{$class}@{$callback[1]}";
+	}
+
+	/**
+	 * Get all dependencies for a given method.
+	 *
+	 * @param Container $container
+	 * @param  callable|string  $callback
+	 * @param  array  $parameters
+	 * @return array
+	 *
+	 * @throws \ReflectionException
+	 */
+	protected static function getMethodDependencies( $container, $callback, array $parameters = [] ) {
+		$dependencies = [];
+
+		foreach ( static::getCallReflector( $callback )->getParameters() as $parameter ) {
+			static::addDependencyForCallParameter( $container, $parameter, $parameters, $dependencies );
+		}
+
+		return array_merge( $dependencies, array_values( $parameters ) );
+	}
+
+	/**
+	 * Get the proper reflection instance for the given callback.
+	 *
+	 * @param  callable|string  $callback
+	 * @return \ReflectionFunctionAbstract
+	 *
+	 * @throws \ReflectionException
+	 */
+	protected static function getCallReflector($callback) {
+		if ( is_string( $callback ) && str_contains( $callback, '::' ) ) {
+			$callback = explode('::', $callback);
+		} elseif (is_object($callback) && ! $callback instanceof Closure) {
+			$callback = [$callback, '__invoke'];
+		}
+
+		return is_array($callback)
+			? new ReflectionMethod($callback[0], $callback[1])
+			: new ReflectionFunction($callback);
+	}
+
+	/**
+	 * Get the dependency for the given call parameter.
+	 *
+	 * @param Container $container
+	 * @param  \ReflectionParameter  $parameter
+	 * @param  array  $parameters
+	 * @param  array  $dependencies
+	 * @return void
+	 *
+	 * @throws BindingResolutionException
+	 */
+	protected static function addDependencyForCallParameter(
+		$container,
+		$parameter,
+		array &$parameters,
+		&$dependencies
+	) {
+		if ( array_key_exists( $paramName = $parameter->getName(), $parameters ) ) {
+			$dependencies[] = $parameters[$paramName];
+
+			unset( $parameters[$paramName] );
+		} elseif ( ! is_null( $className = Util::getParameterClassName( $parameter ) ) ) {
+			if ( array_key_exists( $className, $parameters ) ) {
+				$dependencies[] = $parameters[$className];
+
+				unset( $parameters[$className] );
+			} elseif ( $parameter->isVariadic() ) {
+				$variadicDependencies = $container->make( $className );
+
+				$dependencies = array_merge($dependencies, is_array($variadicDependencies)
+					? $variadicDependencies
+					: [$variadicDependencies]);
+			} else {
+				$dependencies[] = $container->make( $className );
+			}
+		} elseif ( $parameter->isDefaultValueAvailable() ) {
+			$dependencies[] = $parameter->getDefaultValue();
+		} elseif ( ! $parameter->isOptional() && ! array_key_exists( $paramName, $parameters ) ) {
+			$message = "Unable to resolve dependency [{$parameter}] in class {$parameter->getDeclaringClass()->getName()}";
+
+			throw new BindingResolutionException( $message );
+		}
+	}
+
+	/**
+	 * Determine if the given string is in Class@method syntax.
+	 *
+	 * @param  mixed  $callback
+	 * @return bool
+	 */
+	protected static function isCallableWithAtSign( $callback ) {
+		return is_string( $callback ) && str_contains( $callback, '@' );
+	}
+}

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -978,18 +978,33 @@ class Container implements ContainerContract, ArrayAccess {
 				continue;
 			}
 
-			// If the class is null, it means the dependency is a string or some other
-			// primitive type which we can not resolve since it is not a class and
-			// we will just bomb out with an error since we have no-where to go.
-			$result = is_null( Util::getParameterClassName( $dependency ) )
-				? $this->resolvePrimitive( $dependency )
-				: $this->resolveClass( $dependency );
+			// try / catch to suppress unresolvablePrimitive() => `Unresolvable dependency resolving`.
+			try {
+				// If the class is null, it means the dependency is a string or some other
+				// primitive type which we can not resolve since it is not a class and
+				// we will just bomb out with an error since we have no-where to go.
+				$result = is_null( Util::getParameterClassName( $dependency ) )
+					? $this->resolvePrimitive( $dependency )
+					: $this->resolveClass( $dependency );
 
-			if ( $dependency->isVariadic() ) {
-				$results = array_merge( $results, $result );
-			} else {
-				$results[] = $result;
+				if ( $dependency->isVariadic() ) {
+					$results = array_merge( $results, $result );
+				} else {
+					$results[] = $result;
+				}
+			} catch ( BindingResolutionException $ex ) {
+				/*
+				// Suppress the fatal error, but log it.
+				$msg =
+					"--- Unresolvable Start ---\n"
+					. $ex->getMessage() . "\n"
+					. print_r($dependency, true) . "\n"
+					. "--- Unresolvable End ---";
+
+				error_log( $msg );
+				*/
 			}
+
 		}
 
 		return $results;

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -601,7 +601,7 @@ class Container implements ContainerContract, ArrayAccess {
 				throw $e;
 			}
 
-			throw new EntryNotFoundException($id, $e->getCode(), $e);
+			throw new EntryNotFoundException($id, is_int($e->getCode()) ? $e->getCode() : 0, $e);
 		}
 	}
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -19,8 +19,17 @@ namespace Hybrid\Container;
 
 use ArrayAccess;
 use Closure;
+use Exception;
+use Hybrid\Contracts\Container\BindingResolutionException;
+use Hybrid\Contracts\Container\CircularDependencyException;
+use Hybrid\Util;
+use InvalidArgumentException;
+use LogicException;
 use ReflectionClass;
 use Hybrid\Contracts\Container\Container as ContainerContract;
+use ReflectionException;
+use ReflectionParameter;
+use TypeError;
 
 /**
  * A simple container for objects.
@@ -29,6 +38,20 @@ use Hybrid\Contracts\Container\Container as ContainerContract;
  * @access public
  */
 class Container implements ContainerContract, ArrayAccess {
+
+	/**
+	 * The current globally available container (if any).
+	 *
+	 * @var static
+	 */
+	protected static $instance;
+
+	/**
+	 * An array of the types that have been resolved.
+	 *
+	 * @var bool[]
+	 */
+	protected $resolved = [];
 
 	/**
 	* Stored definitions of objects.
@@ -40,31 +63,127 @@ class Container implements ContainerContract, ArrayAccess {
 	protected $bindings = [];
 
 	/**
+	 * The container's method bindings.
+	 *
+	 * @var Closure[]
+	 */
+	protected $methodBindings = [];
+
+	/**
+	 * The container's shared instances.
+	 *
+	 * @since  5.0.0
+	 * @access protected
+	 * @var object[]
+	 */
+	protected $instances = [];
+
+	/**
+	 * The container's scoped instances.
+	 *
+	 * @var array
+	 */
+	protected $scopedInstances = [];
+
+	/**
 	 * Array of aliases for bindings.
 	 *
 	 * @since  5.0.0
 	 * @access protected
-	 * @var    array
+	 * @var string[]
 	 */
 	protected $aliases = [];
 
 	/**
-	* Array of single instance objects.
-	*
-	* @since  5.0.0
-	* @access protected
-	* @var    array
-	*/
-	protected $instances = [];
+	 * The registered aliases keyed by the abstract name.
+	 *
+	 * @var array[]
+	 */
+	protected $abstractAliases = [];
 
 	/**
-	* Array of object extensions.
-	*
-	* @since  5.0.0
-	* @access protected
-	* @var    array
-	*/
-	protected $extensions = [];
+	 * The extension closures for services.
+	 *
+	 * @var array[]
+	 */
+	protected $extenders = [];
+
+	/**
+	 * All of the registered tags.
+	 *
+	 * @var array[]
+	 */
+	protected $tags = [];
+
+	/**
+	 * The stack of concretions currently being built.
+	 *
+	 * @var array[]
+	 */
+	protected $buildStack = [];
+
+	/**
+	 * The parameter override stack.
+	 *
+	 * @var array[]
+	 */
+	protected $with = [];
+
+	/**
+	 * The contextual binding map.
+	 *
+	 * @var array[]
+	 */
+	public $contextual = [];
+
+	/**
+	 * All of the registered rebound callbacks.
+	 *
+	 * @var array[]
+	 */
+	protected $reboundCallbacks = [];
+
+	/**
+	 * All of the global before resolving callbacks.
+	 *
+	 * @var Closure[]
+	 */
+	protected $globalBeforeResolvingCallbacks = [];
+
+	/**
+	 * All of the global resolving callbacks.
+	 *
+	 * @var Closure[]
+	 */
+	protected $globalResolvingCallbacks = [];
+
+	/**
+	 * All of the global after resolving callbacks.
+	 *
+	 * @var Closure[]
+	 */
+	protected $globalAfterResolvingCallbacks = [];
+
+	/**
+	 * All of the before resolving callbacks by class type.
+	 *
+	 * @var array[]
+	 */
+	protected $beforeResolvingCallbacks = [];
+
+	/**
+	 * All of the resolving callbacks by class type.
+	 *
+	 * @var array[]
+	 */
+	protected $resolvingCallbacks = [];
+
+	/**
+	 * All of the after resolving callbacks by class type.
+	 *
+	 * @var array[]
+	 */
+	protected $afterResolvingCallbacks = [];
 
 	/**
 	* Set up a new container.
@@ -82,6 +201,34 @@ class Container implements ContainerContract, ArrayAccess {
 	}
 
 	/**
+	 * Define a contextual binding.
+	 *
+	 * @param  array|string  $concrete
+	 * @return ContextualBindingBuilder
+	 */
+	public function when( $concrete ) {
+		$aliases = [];
+
+		foreach ( Util::arrayWrap( $concrete ) as $c ) {
+			$aliases[] = $this->getAlias( $c );
+		}
+
+		return new ContextualBindingBuilder( $this, $aliases );
+	}
+
+	/**
+	 * Determine if the given abstract type has been bound.
+	 *
+	 * @param  string  $abstract
+	 * @return bool
+	 */
+	public function bound( $abstract ) {
+		return isset( $this->bindings[$abstract] ) ||
+			isset( $this->instances[$abstract] ) ||
+			$this->isAlias( $abstract );
+	}
+
+	/**
 	 * Add a binding. The abstract should be a key, abstract class name, or
 	 * interface name. The concrete should be the concrete implementation of
 	 * the abstract. If no concrete is given, its assumed the abstract
@@ -90,32 +237,1285 @@ class Container implements ContainerContract, ArrayAccess {
 	 * @since  5.0.0
 	 * @access public
 	 * @param  string  $abstract
+	 * @param  Closure|string|null  $concrete
+	 * @param  bool  $shared
+	 * @return void
+	 *
+	 * @throws \TypeError
+	 */
+	public function bind( $abstract, $concrete = null, $shared = false ) {
+		$this->dropStaleInstances( $abstract );
+
+		// If no concrete type was given, we will simply set the concrete type to the
+		// abstract type. After that, the concrete type to be registered as shared
+		// without being forced to state their classes in both of the parameters.
+		if (is_null($concrete)) {
+			$concrete = $abstract;
+		}
+
+		// If the factory is not a Closure, it means it is just a class name which is
+		// bound into this container to the abstract type and we will just wrap it
+		// up inside its own Closure to give us more convenience when extending.
+		if ( ! $concrete instanceof Closure ) {
+			if ( ! is_string( $concrete ) ) {
+				throw new TypeError(self::class.'::bind(): Argument #2 ($concrete) must be of type Closure|string|null');
+			}
+
+			$concrete = $this->getClosure( $abstract, $concrete );
+		}
+
+		$this->bindings[$abstract] = compact('concrete', 'shared');
+
+		// If the abstract type was already resolved in this container we'll fire the
+		// rebound listener so that any objects which have already gotten resolved
+		// can have their copy of the object updated via the listener callbacks.
+		if ( $this->resolved( $abstract ) ) {
+			$this->rebound( $abstract );
+		}
+	}
+
+	/**
+	 * Get the Closure to be used when building a type.
+	 *
+	 * @param  string  $abstract
+	 * @param  string  $concrete
+	 * @return Closure
+	 */
+	protected function getClosure( $abstract, $concrete ) {
+		return function ( $container, $parameters = [] ) use ( $abstract, $concrete ) {
+			if ( $abstract == $concrete ) {
+				return $container->build( $concrete );
+			}
+
+			return $container->resolve(
+				$concrete, $parameters, $raiseEvents = false
+			);
+		};
+	}
+
+	/**
+	 * Determine if the container has a method binding.
+	 *
+	 * @param  string  $method
+	 * @return bool
+	 */
+	public function hasMethodBinding( $method ) {
+		return isset( $this->methodBindings[$method] );
+	}
+
+	/**
+	 * Bind a callback to resolve with Container::call.
+	 *
+	 * @param  array|string  $method
+	 * @param Closure $callback
+	 * @return void
+	 */
+	public function bindMethod( $method, $callback ) {
+		$this->methodBindings[$this->parseBindMethod($method)] = $callback;
+	}
+
+	/**
+	 * Get the method to be bound in class@method format.
+	 *
+	 * @param  array|string  $method
+	 * @return string
+	 */
+	protected function parseBindMethod( $method ) {
+		if ( is_array( $method ) ) {
+			return $method[0].'@'.$method[1];
+		}
+
+		return $method;
+	}
+
+	/**
+	 * Get the method binding for the given method.
+	 *
+	 * @param  string  $method
+	 * @param  mixed  $instance
+	 * @return mixed
+	 */
+	public function callMethodBinding( $method, $instance ) {
+		return call_user_func( $this->methodBindings[$method], $instance, $this );
+	}
+
+	/**
+	 * Add a contextual binding to the container.
+	 *
+	 * @param  string  $concrete
+	 * @param  string  $abstract
+	 * @param  Closure|string  $implementation
+	 * @return void
+	 */
+	public function addContextualBinding( $concrete, $abstract, $implementation ) {
+		$this->contextual[$concrete][$this->getAlias( $abstract )] = $implementation;
+	}
+
+	/**
+	 * Register a binding if it hasn't already been registered.
+	 *
+	 * @param  string  $abstract
+	 * @param  Closure|string|null  $concrete
+	 * @param  bool  $shared
+	 * @return void
+	 */
+	public function bindIf( $abstract, $concrete = null, $shared = false ) {
+		if ( ! $this->bound( $abstract ) ) {
+			$this->bind( $abstract, $concrete, $shared );
+		}
+	}
+
+	/**
+	 * Resolve and return the given type.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string|callable  $abstract
+	 * @param  array  $parameters
+	 * @param  bool  $raiseEvents
+	 * @return mixed
+	 *
+	 * @throws BindingResolutionException|CircularDependencyException|ReflectionException
+	 */
+	public function resolve( $abstract, $parameters = [], $raiseEvents = true ) {
+		$abstract = $this->getAlias( $abstract );
+
+		// First we'll fire any event handlers which handle the "before" resolving of
+		// specific types. This gives some hooks the chance to add various extends
+		// calls to change the resolution of objects that they're interested in.
+		if ( $raiseEvents ) {
+			$this->fireBeforeResolvingCallbacks( $abstract, $parameters );
+		}
+
+		$concrete = $this->getContextualConcrete( $abstract );
+
+		$needsContextualBuild = ! empty( $parameters ) || ! is_null( $concrete );
+
+		// If an instance of the type is currently being managed as a singleton we'll
+		// just return an existing instance instead of instantiating new instances
+		// so the developer can keep using the same objects instance every time.
+		if ( isset( $this->instances[$abstract] ) && ! $needsContextualBuild ) {
+			return $this->instances[$abstract];
+		}
+
+		$this->with[] = $parameters;
+
+		if ( is_null( $concrete ) ) {
+			$concrete = $this->getConcrete( $abstract );
+		}
+
+		// We're ready to instantiate an instance of the concrete type registered for
+		// the binding. This will instantiate the types, as well as resolve any of
+		// its "nested" dependencies recursively until all have gotten resolved.
+		if ( $this->isBuildable( $concrete, $abstract ) ) {
+			$object = $this->build( $concrete );
+		} else {
+			$object = $this->make( $concrete );
+		}
+
+		// If we defined any extenders for this type, we'll need to spin through them
+		// and apply them to the object being built. This allows for the extension
+		// of services, such as changing configuration or decorating the object.
+		foreach ( $this->getExtenders( $abstract ) as $extender ) {
+			$object = $extender( $object, $this );
+		}
+
+		// If the requested type is registered as a singleton we'll want to cache off
+		// the instances in "memory" so we can return it later without creating an
+		// entirely new instance of an object on each subsequent request for it.
+		if ( $this->isShared( $abstract ) && ! $needsContextualBuild ) {
+			$this->instances[$abstract] = $object;
+		}
+
+		if ( $raiseEvents ) {
+			$this->fireResolvingCallbacks( $abstract, $object );
+		}
+
+		// Before returning, we will also set the resolved flag to "true" and pop off
+		// the parameter overrides for this build. After those two things are done
+		// we will be ready to return back the fully constructed class instance.
+		$this->resolved[$abstract] = true;
+
+		array_pop( $this->with );
+
+		return $object;
+	}
+
+	/**
+	 * Creates an alias for a type. This allows you to add names that
+	 * are easy to access without remembering more complex class names.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $abstract
+	 * @param  string  $alias
+	 * @return void
+	 *
+	 * @throws LogicException
+	 */
+	public function alias( $abstract, $alias ) {
+		if ( $alias === $abstract ) {
+			throw new LogicException( "[{$abstract}] is aliased to itself." );
+		}
+
+		$this->aliases[$alias] = $abstract;
+
+		$this->abstractAliases[$abstract][] = $alias;
+	}
+
+	/**
+	 * Bind a new callback to an abstract's rebind event.
+	 *
+	 * @param  string  $abstract
+	 * @param  Closure $callback
+	 * @return mixed
+	 */
+	public function rebinding( $abstract, Closure $callback ) {
+		$this->reboundCallbacks[$abstract = $this->getAlias( $abstract )][] = $callback;
+
+		if ( $this->bound( $abstract ) ) {
+			return $this->make( $abstract );
+		}
+	}
+
+	/**
+	 * Refresh an instance on the given target and method.
+	 *
+	 * @param  string  $abstract
+	 * @param  mixed  $target
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	public function refresh( $abstract, $target, $method ) {
+		return $this->rebinding( $abstract, function ( $app, $instance ) use ( $target, $method ) {
+			$target->{$method}($instance);
+		} );
+	}
+
+	/**
+	 * Fire the "rebound" callbacks for the given abstract type.
+	 *
+	 * @param  string  $abstract
+	 * @return void
+	 */
+	protected function rebound( $abstract ) {
+		$instance = $this->make( $abstract );
+
+		foreach ( $this->getReboundCallbacks( $abstract ) as $callback ) {
+			$callback( $this, $instance );
+		}
+	}
+
+	/**
+	 * Get the rebound callbacks for a given type.
+	 *
+	 * @param  string  $abstract
+	 * @return array
+	 */
+	protected function getReboundCallbacks( $abstract ) {
+		return $this->reboundCallbacks[$abstract] ?? [];
+	}
+
+	/**
+	 * Wrap the given closure such that its dependencies will be injected when executed.
+	 *
+	 * @param  Closure $callback
+	 * @param  array  $parameters
+	 * @return Closure
+	 */
+	public function wrap( Closure $callback, array $parameters = [] ) {
+		return function () use ( $callback, $parameters ) {
+			return $this->call( $callback, $parameters );
+		};
+	}
+
+	/**
+	 * Call the given Closure / class@method and inject its dependencies.
+	 *
+	 * @param  callable|string  $callback
+	 * @param  array<string, mixed>  $parameters
+	 * @param  string|null  $defaultMethod
+	 * @return mixed
+	 *
+	 * @throws InvalidArgumentException|ReflectionException
+	 */
+	public function call( $callback, array $parameters = [], $defaultMethod = null ) {
+		return BoundMethod::call( $this, $callback, $parameters, $defaultMethod );
+	}
+
+	/**
+	 * Get a closure to resolve the given type from the container.
+	 *
+	 * @param  string  $abstract
+	 * @return Closure
+	 */
+	public function factory( $abstract ) {
+		return function () use ( $abstract ) {
+			return $this->make( $abstract );
+		};
+	}
+
+	/**
+	 * An alias function name for make().
+	 *
+	 * @param  string|callable  $abstract
+	 * @param  array  $parameters
+	 * @return mixed
+	 *
+	 * @throws BindingResolutionException
+	 */
+	public function makeWith( $abstract, array $parameters = [] ) {
+		return $this->make( $abstract, $parameters );
+	}
+
+	/**
+	 * Resolve the given type from the container.
+	 *
+	 * @param  string|callable  $abstract
+	 * @param  array  $parameters
+	 * @return mixed
+	 *
+	 * @throws BindingResolutionException
+	 */
+	public function make( $abstract, array $parameters = [] ) {
+		return $this->resolve( $abstract, $parameters );
+	}
+
+	/**
+	 * Alias for `resolve()`.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 *
+	 * @param  string  $id
+	 * @return mixed
+	 *
+	 * @throws CircularDependencyException
+	 * @throws EntryNotFoundException
+	 */
+	public function get( $id ) {
+		try {
+			return $this->resolve( $id );
+		} catch ( Exception $e ) {
+			if ($this->has($id) || $e instanceof CircularDependencyException) {
+				throw $e;
+			}
+
+			throw new EntryNotFoundException($id, $e->getCode(), $e);
+		}
+	}
+
+	/**
+	* Check if a binding exists.
+	*
+	* @since  5.0.0
+	* @access public
+	 *
+	* @param  string  $id
+	* @return bool
+	*/
+	public function has( $id ): bool {
+		return $this->bound( $id );
+	}
+
+	/**
+	 * Determine if the given abstract type has been resolved.
+	 *
+	 * @param  string  $abstract
+	 * @return bool
+	 */
+	public function resolved( $abstract ) {
+		if ( $this->isAlias( $abstract ) ) {
+			$abstract = $this->getAlias( $abstract );
+		}
+
+		return isset( $this->resolved[$abstract] ) ||
+			isset( $this->instances[$abstract] );
+	}
+
+	/**
+	 * Determine if a given type is shared.
+	 *
+	 * @param  string  $abstract
+	 * @return bool
+	 */
+	public function isShared( $abstract ) {
+		return isset( $this->instances[$abstract] ) ||
+			( isset( $this->bindings[$abstract]['shared'] ) &&
+				$this->bindings[$abstract]['shared'] === true );
+	}
+
+	/**
+	 * Determine if a given string is an alias.
+	 *
+	 * @param  string  $name
+	 * @return bool
+	 */
+	public function isAlias( $name ) {
+		return isset( $this->aliases[$name] );
+	}
+
+	/**
+	 * Add a shared binding.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $abstract
+	 * @param  Closure|string|null  $concrete
+	 * @return void
+	 */
+	public function singleton( $abstract, $concrete = null ) {
+		$this->bind( $abstract, $concrete, true );
+	}
+
+	/**
+	 * Register a shared binding if it hasn't already been registered.
+	 *
+	 * @param  string  $abstract
+	 * @param  Closure|string|null  $concrete
+	 * @return void
+	 */
+	public function singletonIf( $abstract, $concrete = null ) {
+		if ( ! $this->bound( $abstract ) ) {
+			$this->singleton( $abstract, $concrete );
+		}
+	}
+
+	/**
+	 * Register a scoped binding in the container.
+	 *
+	 * @param  string  $abstract
+	 * @param  Closure|string|null  $concrete
+	 * @return void
+	 */
+	public function scoped( $abstract, $concrete = null ) {
+		$this->scopedInstances[] = $abstract;
+
+		$this->singleton( $abstract, $concrete );
+	}
+
+	/**
+	 * Register a scoped binding if it hasn't already been registered.
+	 *
+	 * @param  string  $abstract
+	 * @param  Closure|string|null  $concrete
+	 * @return void
+	 */
+	public function scopedIf( $abstract, $concrete = null ) {
+		if ( ! $this->bound( $abstract ) ) {
+			$this->scoped( $abstract, $concrete );
+		}
+	}
+
+	/**
+	 * Add an existing instance. This can be an instance of an object or a
+	 * single value that should be stored.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $abstract
+	 * @param  mixed   $instance
+	 * @return mixed
+	 */
+	public function instance( $abstract, $instance ) {
+		$this->removeAbstractAlias( $abstract );
+
+		$isBound = $this->bound( $abstract );
+
+		unset( $this->aliases[$abstract] );
+
+		// We'll check to determine if this type has been bound before, and if it has
+		// we will fire the rebound callbacks registered with the container and it
+		// can be updated with consuming classes that have gotten resolved here.
+		$this->instances[$abstract] = $instance;
+
+		if ( $isBound ) {
+			$this->rebound( $abstract );
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Remove an alias from the contextual binding alias cache.
+	 *
+	 * @param  string  $searched
+	 * @return void
+	 */
+	protected function removeAbstractAlias( $searched ) {
+		if ( ! isset( $this->aliases[$searched] ) ) {
+			return;
+		}
+
+		foreach ( $this->abstractAliases as $abstract => $aliases ) {
+			foreach ( $aliases as $index => $alias ) {
+				if ( $alias == $searched ) {
+					unset( $this->abstractAliases[$abstract][$index] );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Assign a set of tags to a given binding.
+	 *
+	 * @param  array|string  $abstracts
+	 * @param  array|mixed  ...$tags
+	 * @return void
+	 */
+	public function tag( $abstracts, $tags ) {
+		$tags = is_array( $tags ) ? $tags : array_slice( func_get_args(), 1 );
+
+		foreach ( $tags as $tag ) {
+			if ( ! isset( $this->tags[$tag] ) ) {
+				$this->tags[$tag] = [];
+			}
+
+			foreach ( (array) $abstracts as $abstract ) {
+				$this->tags[$tag][] = $abstract;
+			}
+		}
+	}
+
+	/**
+	 * Resolve all of the bindings for a given tag.
+	 *
+	 * @param  string  $tag
+	 * @return iterable
+	 */
+	public function tagged($tag) {
+		if ( ! isset( $this->tags[$tag] ) ) {
+			return [];
+		}
+
+		return new RewindableGenerator( function () use ($tag) {
+			foreach ( $this->tags[$tag] as $abstract ) {
+				yield $this->make( $abstract );
+			}
+		}, count( $this->tags[$tag] ) );
+	}
+
+	/**
+	 * Extend a binding with something like a decorator class. Cannot
+	 * extend resolved instances.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $abstract
+	 * @param  Closure  $closure
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function extend( $abstract, Closure $closure ) {
+		$abstract = $this->getAlias( $abstract );
+
+		if ( isset( $this->instances[$abstract] ) ) {
+			$this->instances[$abstract] = $closure( $this->instances[$abstract], $this );
+
+			$this->rebound( $abstract );
+		} else {
+			$this->extenders[$abstract][] = $closure;
+
+			if ( $this->resolved( $abstract ) ) {
+				$this->rebound( $abstract );
+			}
+		}
+	}
+
+	/**
+	 * Get the concrete type for a given abstract.
+	 *
+	 * @since  5.0.0
+	 * @access protected
+	 * @param  string|callable  $abstract
+	 * @return mixed
+	 */
+	protected function getConcrete( $abstract ) {
+
+		// If we don't have a registered resolver or concrete for the type, we'll just
+		// assume each type is a concrete name and will attempt to resolve it as is
+		// since the container should be able to resolve concretes automatically.
+		if ( isset( $this->bindings[$abstract] ) ) {
+			return $this->bindings[$abstract]['concrete'];
+		}
+
+		return $abstract;
+	}
+
+	/**
+	 * Get the contextual concrete binding for the given abstract.
+	 *
+	 * @param  string|callable  $abstract
+	 * @return Closure|string|array|null
+	 */
+	protected function getContextualConcrete( $abstract ) {
+		if ( ! is_null( $binding = $this->findInContextualBindings( $abstract ) ) ) {
+			return $binding;
+		}
+
+		// Next we need to see if a contextual binding might be bound under an alias of the
+		// given abstract type. So, we will need to check if any aliases exist with this
+		// type and then spin through them and check for contextual bindings on these.
+		if ( empty( $this->abstractAliases[$abstract] ) ) {
+			return;
+		}
+
+		foreach ( $this->abstractAliases[$abstract] as $alias ) {
+			if ( ! is_null( $binding = $this->findInContextualBindings( $alias ) ) ) {
+				return $binding;
+			}
+		}
+	}
+
+	/**
+	 * Find the concrete binding for the given abstract in the contextual binding array.
+	 *
+	 * @param  string|callable  $abstract
+	 * @return Closure|string|null
+	 */
+	protected function findInContextualBindings( $abstract ) {
+		return $this->contextual[end($this->buildStack)][$abstract] ?? null;
+	}
+
+	/**
+	 * Determine if the given concrete is buildable.
+	 *
+	 * @since  5.0.0
+	 * @access protected
+	 * @param  mixed  $concrete
+	 * @param  string  $abstract
+	 * @return bool
+	 */
+	protected function isBuildable( $concrete, $abstract ) {
+		return $concrete === $abstract || $concrete instanceof Closure;
+	}
+
+	/**
+	 * Instantiate a concrete instance of the given type.
+	 *
+	 * @since  5.0.0
+	 * @access protected
+	 * @param  Closure|string  $concrete
+	 * @return mixed
+	 *
+	 * @throws BindingResolutionException|CircularDependencyException|ReflectionException
+	 */
+	public function build( $concrete ) {
+
+		// If the concrete type is actually a Closure, we will just execute it and
+		// hand back the results of the functions, which allows functions to be
+		// used as resolvers for more fine-tuned resolution of these objects.
+		if ( $concrete instanceof Closure ) {
+			return $concrete( $this, $this->getLastParameterOverride() );
+		}
+
+		try {
+			$reflector = new ReflectionClass( $concrete );
+		} catch ( ReflectionException $e ) {
+			throw new BindingResolutionException( "Target class [$concrete] does not exist.", 0, $e );
+		}
+
+		// If the type is not instantiable, the developer is attempting to resolve
+		// an abstract type such as an Interface or Abstract Class and there is
+		// no binding registered for the abstractions so we need to bail out.
+		if ( ! $reflector->isInstantiable() ) {
+			return $this->notInstantiable( $concrete );
+		}
+
+		$this->buildStack[] = $concrete;
+
+		$constructor = $reflector->getConstructor();
+
+		// If there are no constructors, that means there are no dependencies then
+		// we can just resolve the instances of the objects right away, without
+		// resolving any other types or dependencies out of these containers.
+		if ( is_null( $constructor ) ) {
+			array_pop($this->buildStack);
+
+			return new $concrete;
+		}
+
+		$dependencies = $constructor->getParameters();
+
+		// Once we have all the constructor's parameters we can create each of the
+		// dependency instances and then use the reflection instances to make a
+		// new instance of this class, injecting the created dependencies in.
+		try {
+			$instances = $this->resolveDependencies( $dependencies );
+		} catch ( BindingResolutionException $e ) {
+			array_pop( $this->buildStack );
+
+			throw $e;
+		}
+
+		array_pop( $this->buildStack );
+
+		return $reflector->newInstanceArgs( $instances );
+	}
+
+	/**
+	 * Resolve all the dependencies from the ReflectionParameters.
+	 *
+	 * @since  5.0.0
+	 * @access protected
+	 * @param  ReflectionParameter[]  $dependencies
+	 * @return array
+	 *
+	 * @throws BindingResolutionException
+	 */
+	protected function resolveDependencies( array $dependencies ) {
+		$results = [];
+
+		foreach ( $dependencies as $dependency ) {
+
+			// If the dependency has an override for this particular build we will use
+			// that instead as the value. Otherwise, we will continue with this run
+			// of resolutions and let reflection attempt to determine the result.
+			if ( $this->hasParameterOverride( $dependency ) ) {
+				$results[] = $this->getParameterOverride( $dependency );
+
+				continue;
+			}
+
+			// If the class is null, it means the dependency is a string or some other
+			// primitive type which we can not resolve since it is not a class and
+			// we will just bomb out with an error since we have no-where to go.
+			$result = is_null( Util::getParameterClassName( $dependency ) )
+				? $this->resolvePrimitive( $dependency )
+				: $this->resolveClass( $dependency );
+
+			if ( $dependency->isVariadic() ) {
+				$results = array_merge( $results, $result );
+			} else {
+				$results[] = $result;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Determine if the given dependency has a parameter override.
+	 *
+	 * @param  ReflectionParameter  $dependency
+	 * @return bool
+	 */
+	protected function hasParameterOverride( $dependency ) {
+		return array_key_exists(
+			$dependency->name, $this->getLastParameterOverride()
+		);
+	}
+
+	/**
+	 * Get a parameter override for a dependency.
+	 *
+	 * @param  ReflectionParameter  $dependency
+	 * @return mixed
+	 */
+	protected function getParameterOverride( $dependency ) {
+		return $this->getLastParameterOverride()[$dependency->name];
+	}
+
+	/**
+	 * Get the last parameter override.
+	 *
+	 * @return array
+	 */
+	protected function getLastParameterOverride() {
+		return count( $this->with ) ? end( $this->with ) : [];
+	}
+
+	/**
+	 * Resolve a non-class hinted primitive dependency.
+	 *
+	 * @param  ReflectionParameter  $parameter
+	 * @return mixed
+	 *
+	 * @throws BindingResolutionException
+	 */
+	protected function resolvePrimitive( ReflectionParameter $parameter ) {
+		if ( ! is_null( $concrete = $this->getContextualConcrete( '$'.$parameter->getName() ) ) ) {
+			return Util::unwrapIfClosure( $concrete, $this );
+		}
+
+		if ( $parameter->isDefaultValueAvailable() ) {
+			return $parameter->getDefaultValue();
+		}
+
+		$this->unresolvablePrimitive( $parameter );
+	}
+
+	/**
+	 * Resolve a class based dependency from the container.
+	 *
+	 * @param  ReflectionParameter  $parameter
+	 * @return mixed
+	 *
+	 * @throws BindingResolutionException
+	 */
+	protected function resolveClass( ReflectionParameter $parameter ) {
+		try {
+			return $parameter->isVariadic()
+				? $this->resolveVariadicClass( $parameter )
+				: $this->make( Util::getParameterClassName( $parameter ) );
+		}
+
+		// If we can not resolve the class instance, we will check to see if the value
+		// is optional, and if it is we will return the optional parameter value as
+		// the value of the dependency, similarly to how we do this with scalars.
+		catch ( BindingResolutionException $e ) {
+			if ( $parameter->isDefaultValueAvailable() ) {
+				array_pop( $this->with );
+
+				return $parameter->getDefaultValue();
+			}
+
+			if ( $parameter->isVariadic() ) {
+				array_pop( $this->with );
+
+				return [];
+			}
+
+			throw $e;
+		}
+	}
+
+	/**
+	 * Resolve a class based variadic dependency from the container.
+	 *
+	 * @param  ReflectionParameter  $parameter
+	 * @return mixed
+	 */
+	protected function resolveVariadicClass( ReflectionParameter $parameter ) {
+		$className = Util::getParameterClassName( $parameter );
+
+		$abstract = $this->getAlias( $className );
+
+		if ( ! is_array( $concrete = $this->getContextualConcrete( $abstract ) ) ) {
+			return $this->make( $className );
+		}
+
+		return array_map( function ( $abstract ) {
+			return $this->resolve( $abstract );
+		}, $concrete );
+	}
+
+	/**
+	 * Throw an exception that the concrete is not instantiable.
+	 *
+	 * @param  string  $concrete
+	 * @return void
+	 *
+	 * @throws BindingResolutionException
+	 */
+	protected function notInstantiable( $concrete ) {
+		if ( ! empty( $this->buildStack ) ) {
+			$previous = implode( ', ', $this->buildStack );
+
+			$message = "Target [$concrete] is not instantiable while building [$previous].";
+		} else {
+			$message = "Target [$concrete] is not instantiable.";
+		}
+
+		throw new BindingResolutionException( $message );
+	}
+
+	/**
+	 * Throw an exception for an unresolvable primitive.
+	 *
+	 * @param  ReflectionParameter  $parameter
+	 * @return void
+	 *
+	 * @throws BindingResolutionException
+	 */
+	protected function unresolvablePrimitive( ReflectionParameter $parameter ) {
+		$message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
+
+		throw new BindingResolutionException($message);
+	}
+
+	/**
+	 * Register a new before resolving callback for all types.
+	 *
+	 * @param  Closure|string  $abstract
+	 * @param  Closure|null  $callback
+	 * @return void
+	 */
+	public function beforeResolving( $abstract, Closure $callback = null ) {
+		if ( is_string( $abstract ) ) {
+			$abstract = $this->getAlias( $abstract );
+		}
+
+		if ( $abstract instanceof Closure && is_null( $callback ) ) {
+			$this->globalBeforeResolvingCallbacks[] = $abstract;
+		} else {
+			$this->beforeResolvingCallbacks[$abstract][] = $callback;
+		}
+	}
+
+	/**
+	 * Register a new resolving callback.
+	 *
+	 * @param  Closure|string  $abstract
+	 * @param  Closure|null  $callback
+	 * @return void
+	 */
+	public function resolving( $abstract, Closure $callback = null ) {
+		if ( is_string( $abstract ) ) {
+			$abstract = $this->getAlias( $abstract );
+		}
+
+		if ( is_null( $callback ) && $abstract instanceof Closure ) {
+			$this->globalResolvingCallbacks[] = $abstract;
+		} else {
+			$this->resolvingCallbacks[$abstract][] = $callback;
+		}
+	}
+
+	/**
+	 * Register a new after resolving callback for all types.
+	 *
+	 * @param  Closure|string  $abstract
+	 * @param  Closure|null  $callback
+	 * @return void
+	 */
+	public function afterResolving( $abstract, Closure $callback = null ) {
+		if ( is_string( $abstract ) ) {
+			$abstract = $this->getAlias( $abstract );
+		}
+
+		if ( $abstract instanceof Closure && is_null( $callback ) ) {
+			$this->globalAfterResolvingCallbacks[] = $abstract;
+		} else {
+			$this->afterResolvingCallbacks[$abstract][] = $callback;
+		}
+	}
+
+	/**
+	 * Fire all of the before resolving callbacks.
+	 *
+	 * @param  string  $abstract
+	 * @param  array  $parameters
+	 * @return void
+	 */
+	protected function fireBeforeResolvingCallbacks( $abstract, $parameters = [] ) {
+		$this->fireBeforeCallbackArray( $abstract, $parameters, $this->globalBeforeResolvingCallbacks );
+
+		foreach ( $this->beforeResolvingCallbacks as $type => $callbacks ) {
+			if ( $type === $abstract || is_subclass_of( $abstract, $type ) ) {
+				$this->fireBeforeCallbackArray( $abstract, $parameters, $callbacks );
+			}
+		}
+	}
+
+	/**
+	 * Fire an array of callbacks with an object.
+	 *
+	 * @param  string  $abstract
+	 * @param  array  $parameters
+	 * @param  array  $callbacks
+	 * @return void
+	 */
+	protected function fireBeforeCallbackArray( $abstract, $parameters, array $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$callback( $abstract, $parameters, $this );
+		}
+	}
+
+	/**
+	 * Fire all of the resolving callbacks.
+	 *
+	 * @param  string  $abstract
+	 * @param  mixed  $object
+	 * @return void
+	 */
+	protected function fireResolvingCallbacks( $abstract, $object ) {
+		$this->fireCallbackArray( $object, $this->globalResolvingCallbacks );
+
+		$this->fireCallbackArray(
+			$object, $this->getCallbacksForType( $abstract, $object, $this->resolvingCallbacks )
+		);
+
+		$this->fireAfterResolvingCallbacks( $abstract, $object );
+	}
+
+	/**
+	 * Fire all of the after resolving callbacks.
+	 *
+	 * @param  string  $abstract
+	 * @param  mixed  $object
+	 * @return void
+	 */
+	protected function fireAfterResolvingCallbacks( $abstract, $object ) {
+		$this->fireCallbackArray( $object, $this->globalAfterResolvingCallbacks );
+
+		$this->fireCallbackArray(
+			$object, $this->getCallbacksForType( $abstract, $object, $this->afterResolvingCallbacks )
+		);
+	}
+
+	/**
+	 * Get all callbacks for a given type.
+	 *
+	 * @param  string  $abstract
+	 * @param  object  $object
+	 * @param  array  $callbacksPerType
+	 * @return array
+	 */
+	protected function getCallbacksForType( $abstract, $object, array $callbacksPerType ) {
+		$results = [];
+
+		foreach ( $callbacksPerType as $type => $callbacks ) {
+			if ( $type === $abstract || $object instanceof $type ) {
+				$results = array_merge( $results, $callbacks );
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Fire an array of callbacks with an object.
+	 *
+	 * @param  mixed  $object
+	 * @param  array  $callbacks
+	 * @return void
+	 */
+	protected function fireCallbackArray( $object, array $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$callback( $object, $this );
+		}
+	}
+
+	/**
+	 * Get the container's bindings.
+	 *
+	 * @return array
+	 */
+	public function getBindings() {
+		return $this->bindings;
+	}
+
+	/**
+	 * Get the alias for an abstract if available.
+	 *
+	 * @param  string  $abstract
+	 * @return string
+	 */
+	public function getAlias( $abstract ) {
+		return isset( $this->aliases[$abstract] )
+			? $this->getAlias( $this->aliases[$abstract] )
+			: $abstract;
+	}
+
+	/**
+	 * Get the extender callbacks for a given type.
+	 *
+	 * @param  string  $abstract
+	 * @return array
+	 */
+	protected function getExtenders( $abstract ) {
+		return $this->extenders[$this->getAlias( $abstract )] ?? [];
+	}
+
+	/**
+	 * Remove all of the extender callbacks for a given type.
+	 *
+	 * @param  string  $abstract
+	 * @return void
+	 */
+	public function forgetExtenders( $abstract ) {
+		unset( $this->extenders[$this->getAlias( $abstract )] );
+	}
+
+	/**
+	 * Drop all of the stale instances and aliases.
+	 *
+	 * @param  string  $abstract
+	 * @return void
+	 */
+	protected function dropStaleInstances( $abstract ) {
+		unset( $this->instances[$abstract], $this->aliases[$abstract] );
+	}
+
+	/**
+	 * Remove a resolved instance from the instance cache.
+	 *
+	 * @param  string  $abstract
+	 * @return void
+	 */
+	public function forgetInstance( $abstract ) {
+		unset( $this->instances[$abstract] );
+	}
+
+	/**
+	 * Clear all of the instances from the container.
+	 *
+	 * @return void
+	 */
+	public function forgetInstances() {
+		$this->instances = [];
+	}
+
+	/**
+	 * Clear all of the scoped instances from the container.
+	 *
+	 * @return void
+	 */
+	public function forgetScopedInstances() {
+		foreach ( $this->scopedInstances as $scoped ) {
+			unset( $this->instances[$scoped] );
+		}
+	}
+
+	/**
+	 * Flush the container of all bindings and resolved instances.
+	 *
+	 * @return void
+	 */
+	public function flush() {
+		$this->aliases = [];
+		$this->resolved = [];
+		$this->bindings = [];
+		$this->instances = [];
+		$this->abstractAliases = [];
+		$this->scopedInstances = [];
+	}
+
+	/**
+	 * Get the globally available instance of the container.
+	 *
+	 * @return static
+	 */
+	public static function getInstance() {
+		if ( is_null( static::$instance ) ) {
+			static::$instance = new static;
+		}
+
+		return static::$instance;
+	}
+
+	/**
+	 * Set the shared instance of the container.
+	 *
+	 * @param ContainerContract|null  $container
+	 * @return ContainerContract|static
+	 */
+	public static function setInstance( ContainerContract $container = null ) {
+		return static::$instance = $container;
+	}
+
+	/**
+	 * Determine if a given offset exists.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function offsetExists( $key ): bool {
+		return $this->bound( $key );
+	}
+
+	/**
+	 * Get the value at a given offset.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $key
+	 * @return mixed
+	 */
+	public function offsetGet($key): mixed {
+		return $this->make($key);
+	}
+
+	/**
+	 * Set the value at a given offset.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $key
+	 * @param  mixed  $value
+	 * @return void
+	 */
+	public function offsetSet( $key, $value ): void {
+		$this->bind( $key, $value instanceof Closure ? $value : function () use ( $value ) {
+			return $value;
+		});
+	}
+
+	/**
+	 * Unset the value at a given offset.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $key
+	 * @return void
+	 */
+	public function offsetUnset( $key ): void {
+		unset( $this->bindings[$key], $this->instances[$key], $this->resolved[$key] );
+	}
+
+	/**
+	 * Dynamically access container services.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $key
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		return $this[$key];
+	}
+
+	/**
+	 * Dynamically set container services.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $key
+	 * @param  mixed  $value
+	 * @return void
+	 */
+	public function __set($key, $value) {
+		$this[$key] = $value;
+	}
+
+	/**
+	 * Magic method when trying to unset a property.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $name
+	 * @return void
+	 */
+	public function __unset( $name ) {
+		$this->remove( $name );
+	}
+
+	/**
+	 * Magic method when trying to check if a property exists.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $name
+	 * @return bool
+	 */
+	public function __isset( $name ) {
+		return $this->has( $name );
+	}
+
+	/**
+	 * Alias for `bind()`.
+	 *
+	 * @since  5.0.0
+	 * @access public
+	 * @param  string  $abstract
 	 * @param  mixed   $concrete
 	 * @param  bool    $shared
 	 * @return void
 	 */
-	public function bind( $abstract, $concrete = null, $shared = false ) {
-
-		unset( $this->instances[ $abstract ] );
-
-		if ( is_null( $concrete ) ) {
-			$concrete = $abstract;
-		}
-
-		$this->bindings[ $abstract ]   = compact( 'concrete', 'shared' );
-		$this->extensions[ $abstract ] = [];
-	}
-
-	/**
-	* Alias for `bind()`.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $abstract
-	* @param  mixed   $concrete
-	* @param  bool    $shared
-	* @return void
-	*/
 	public function add( $abstract, $concrete = null, $shared = false ) {
 		$this->bind( $abstract, $concrete, $shared );
 	}
@@ -136,147 +1536,6 @@ class Container implements ContainerContract, ArrayAccess {
 	}
 
 	/**
-	 * Resolve and return the binding.
-	 *
-	 * @since  5.0.0
-	 * @access public
-	 * @param  string  $abstract
-	 * @param  array   $parameters
-	 * @return mixed
-	 */
-	public function resolve( $abstract, array $parameters = [] ) {
-
-		// Get the true abstract name.
-		$abstract = $this->getAbstract( $abstract );
-
-		// If this is being managed as an instance and we already have
-		// the instance, return it now.
-		if ( isset( $this->instances[ $abstract ] ) ) {
-			return $this->instances[ $abstract ];
-		}
-
-		// Get the concrete implementation.
-		$concrete = $this->getConcrete( $abstract );
-
-		// If we can't build an object, assume we should return the value.
-		if ( ! $this->isBuildable( $concrete ) ) {
-
-			// If we don't actually have this, return false.
-			if ( ! $this->has( $abstract ) ) {
-				return false;
-			}
-
-			return $concrete;
-		}
-
-		// Build the object.
-		$object = $this->build( $concrete, $parameters );
-
-		if ( ! $this->has( $abstract ) ) {
-			return $object;
-		}
-
-		// If shared instance, make sure to store it in the instances
-		// array so that we're not creating new objects later.
-		if ( $this->bindings[ $abstract ]['shared'] && ! isset( $this->instances[ $abstract ] ) ) {
-			$this->instances[ $abstract ] = $object;
-		}
-
-		// Run through each of the extensions for the object.
-		foreach ( $this->extensions[ $abstract ] as $extension ) {
-			$object = new $extension( $object, $this );
-		}
-
-		// Return the object.
-		return $object;
-	}
-
-	/**
-	 * Creates an alias for an abstract. This allows you to add names that
-	 * are easy to access without remembering more complex class names.
-	 *
-	 * @since  5.0.0
-	 * @access public
-	 * @param  string  $abstract
-	 * @param  string  $alias
-	 * @return void
-	 */
-	public function alias( $abstract, $alias ) {
-		$this->aliases[ $alias ] = $abstract;
-	}
-
-	/**
-	* Alias for `resolve()`.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $abstract
-	* @return object
-	*/
-	public function get( $abstract ) {
-		return $this->resolve( $abstract );
-	}
-
-	/**
-	* Check if a binding exists.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $abstract
-	* @return bool
-	*/
-	public function has( $abstract ) {
-		return isset( $this->bindings[ $abstract ] ) || isset( $this->instances[ $abstract ] );
-	}
-
-	/**
-	 * Add a shared binding.
-	 *
-	 * @since  5.0.0
-	 * @access public
-	 * @param  string  $abstract
-	 * @param  object  $concrete
-	 * @return void
-	 */
-	public function singleton( $abstract, $concrete = null ) {
-		$this->add( $abstract, $concrete, true );
-	}
-
-	/**
-	 * Add an existing instance. This can be an instance of an object or a
-	 * single value that should be stored.
-	 *
-	 * @since  5.0.0
-	 * @access public
-	 * @param  string  $abstract
-	 * @param  mixed   $instance
-	 * @return mixed
-	 */
-	public function instance( $abstract, $instance ) {
-
-		$this->instances[ $abstract ] = $instance;
-
-		return $instance;
-	}
-
-	/**
-	 * Extend a binding with something like a decorator class. Cannot
-	 * extend resolved instances.
-	 *
-	 * @since  5.0.0
-	 * @access public
-	 * @param  string  $abstract
-	 * @param  Closure $closure
-	 * @return void
-	 */
-	public function extend( $abstract, Closure $closure ) {
-
-		$abstract = $this->getAbstract( $abstract );
-
-		$this->extensions[ $abstract ][] = $closure;
-	}
-
-	/**
 	 * Checks if we're dealing with an alias and returns the abstract. If
 	 * not an alias, return the abstract passed in.
 	 *
@@ -292,206 +1551,5 @@ class Container implements ContainerContract, ArrayAccess {
 		}
 
 		return $abstract;
-	}
-
-	/**
-	 * Gets the concrete of an abstract.
-	 *
-	 * @since  5.0.0
-	 * @access protected
-	 * @param  string    $abstract
-	 * @return mixed
-	 */
-	protected function getConcrete( $abstract ) {
-
-		$concrete = false;
-		$abstract = $this->getAbstract( $abstract );
-
-		if ( $this->has( $abstract ) ) {
-			$concrete = $this->bindings[ $abstract ]['concrete'];
-		}
-
-		return $concrete ?: $abstract;
-	}
-
-	/**
-	 * Determines if a concrete is buildable. It should either be a closure
-	 * or a concrete class.
-	 *
-	 * @since  5.0.0
-	 * @access protected
-	 * @param  mixed    $concrete
-	 * @return bool
-	 */
-	protected function isBuildable( $concrete ) {
-
-		return $concrete instanceof Closure
-		       || ( is_string( $concrete ) && class_exists( $concrete ) );
-	}
-
-	/**
-	 * Builds the concrete implementation. If a closure, we'll simply return
-	 * the closure and pass the included parameters. Otherwise, we'll resolve
-	 * the dependencies for the class and return a new object.
-	 *
-	 * @since  5.0.0
-	 * @access protected
-	 * @param  mixed  $concrete
-	 * @param  array  $parameters
-	 * @return object
-	 */
-	protected function build( $concrete, array $parameters = [] ) {
-
-		if ( $concrete instanceof Closure ) {
-			return $concrete( $this, $parameters );
-		}
-
-		$reflect = new ReflectionClass( $concrete );
-
-		$constructor = $reflect->getConstructor();
-
-		if ( ! $constructor ) {
-			return new $concrete();
-		}
-
-		return $reflect->newInstanceArgs(
-			$this->resolveDependencies( $constructor->getParameters(), $parameters )
-		);
-	}
-
-	/**
-	 * Resolves the dependencies for a method's parameters.
-	 *
-	 * @todo Handle errors when we can't solve a dependency.
-	 *
-	 * @since  5.0.0
-	 * @access protected
-	 * @param  array     $dependencies
-	 * @param  array     $parameters
-	 * @return array
-	 */
-	protected function resolveDependencies( array $dependencies, array $parameters ) {
-
-		$args = [];
-
-		foreach ( $dependencies as $dependency ) {
-
-			// If a dependency is set via the parameters passed in, use it.
-			if ( isset( $parameters[ $dependency->getName() ] ) ) {
-
-				$args[] = $parameters[ $dependency->getName() ];
-
-			// If the parameter is a class, resolve it.
-			} elseif ( ! is_null( $dependency->getType() ) && class_exists( $dependency->getType()->getName() ) ) {
-
-				$args[] = $this->resolve( $dependency->getType()->getName() );
-
-			// Else, use the default parameter value.
-			} elseif ( $dependency->isDefaultValueAvailable() ) {
-
-				$args[] = $dependency->getDefaultValue();
-			}
-		}
-
-		return $args;
-	}
-
-	/**
-	* Sets a property via `ArrayAccess`.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @param  mixed   $value
-	* @return void
-	*/
-	public function offsetSet( $name, $value ) {
-		$this->add( $name, $value );
-	}
-
-	/**
-	* Unsets a property via `ArrayAccess`.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @return void
-	*/
-	public function offsetUnset( $name ) {
-		$this->remove( $name );
-	}
-
-	/**
-	* Checks if a property exists via `ArrayAccess`.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @return bool
-	*/
-	public function offsetExists( $name ) {
-		return $this->has( $name );
-	}
-
-	/**
-	* Returns a property via `ArrayAccess`.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @return mixed
-	*/
-	public function offsetGet( $name ) {
-		return $this->get( $name );
-	}
-
-
-	/**
-	* Magic method when trying to set a property.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @param  mixed   $value
-	* @return void
-	*/
-	public function __set( $name, $value ) {
-		$this->add( $name, $value );
-	}
-
-	/**
-	* Magic method when trying to unset a property.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @return void
-	*/
-	public function __unset( $name ) {
-		$this->remove( $name );
-	}
-
-	/**
-	* Magic method when trying to check if a property exists.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @return bool
-	*/
-	public function __isset( $name ) {
-		return $this->has( $name );
-	}
-
-	/**
-	* Magic method when trying to get a property.
-	*
-	* @since  5.0.0
-	* @access public
-	* @param  string  $name
-	* @return mixed
-	*/
-	public function __get( $name ) {
-		return $this->get( $name );
 	}
 }

--- a/src/Container/ContextualBindingBuilder.php
+++ b/src/Container/ContextualBindingBuilder.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Hybrid\Container;
+
+use Hybrid\Util;
+use Hybrid\Contracts\Container\Container;
+use Hybrid\Contracts\Container\ContextualBindingBuilder as ContextualBindingBuilderContract;
+
+class ContextualBindingBuilder implements ContextualBindingBuilderContract {
+
+	/**
+	 * The underlying container instance.
+	 *
+	 * @var \Hybrid\Contracts\Container\Container
+	 */
+	protected $container;
+
+	/**
+	 * The concrete instance.
+	 *
+	 * @var string|array
+	 */
+	protected $concrete;
+
+	/**
+	 * The abstract target.
+	 *
+	 * @var string
+	 */
+	protected $needs;
+
+	/**
+	 * Create a new contextual binding builder.
+	 *
+	 * @param Container $container
+	 * @param string|array $concrete
+	 */
+	public function __construct( Container $container, $concrete ) {
+		$this->concrete = $concrete;
+		$this->container = $container;
+	}
+
+	/**
+	 * Define the abstract target that depends on the context.
+	 *
+	 * @param  string  $abstract
+	 * @return $this
+	 */
+	public function needs( $abstract ) {
+		$this->needs = $abstract;
+
+		return $this;
+	}
+
+	/**
+	 * Define the implementation for the contextual binding.
+	 *
+	 * @param  \Closure|string|array  $implementation
+	 * @return void
+	 */
+	public function give( $implementation ) {
+		foreach ( Util::arrayWrap( $this->concrete ) as $concrete ) {
+			$this->container->addContextualBinding( $concrete, $this->needs, $implementation );
+		}
+	}
+
+	/**
+	 * Define tagged services to be used as the implementation for the contextual binding.
+	 *
+	 * @param  string  $tag
+	 * @return void
+	 */
+	public function giveTagged( $tag ) {
+		$this->give( function ( $container ) use ( $tag ) {
+			$taggedServices = $container->tagged( $tag );
+
+			return is_array( $taggedServices ) ? $taggedServices : iterator_to_array( $taggedServices );
+		} );
+	}
+
+	/**
+	 * Specify the configuration item to bind as a primitive.
+	 *
+	 * @param  string  $key
+	 * @param  mixed  $default
+	 * @return void
+	 */
+	public function giveConfig( $key, $default = null ) {
+		$this->give( fn ( $container ) => $container->get('config')->get( $key, $default ) );
+	}
+}

--- a/src/Container/EntryNotFoundException.php
+++ b/src/Container/EntryNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hybrid\Container;
+
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+
+class EntryNotFoundException extends Exception implements NotFoundExceptionInterface {
+	//
+}

--- a/src/Container/RewindableGenerator.php
+++ b/src/Container/RewindableGenerator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Hybrid\Container;
+
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+class RewindableGenerator implements Countable, IteratorAggregate {
+
+	/**
+	 * The generator callback.
+	 *
+	 * @var callable
+	 */
+	protected $generator;
+
+	/**
+	 * The number of tagged services.
+	 *
+	 * @var callable|int
+	 */
+	protected $count;
+
+	/**
+	 * Create a new generator instance.
+	 *
+	 * @param  callable  $generator
+	 * @param  callable|int  $count
+	 * @return void
+	 */
+	public function __construct( callable $generator, $count ) {
+		$this->count = $count;
+		$this->generator = $generator;
+	}
+
+	/**
+	 * Get an iterator from the generator.
+	 *
+	 * @return \Traversable
+	 */
+	public function getIterator(): Traversable {
+		return ($this->generator)();
+	}
+
+	/**
+	 * Get the total number of tagged services.
+	 *
+	 * @return int
+	 */
+	public function count(): int {
+		if (is_callable($count = $this->count)) {
+			$this->count = $count();
+		}
+
+		return $this->count;
+	}
+}

--- a/src/Contracts/Container/BindingResolutionException.php
+++ b/src/Contracts/Container/BindingResolutionException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Container Exception class.
+ *
+ * @package   HybridCore
+ * @author    Justin Tadlock <justintadlock@gmail.com>
+ * @copyright Copyright (c) 2008 - 2022, Justin Tadlock
+ * @link      https://themehybrid.com/hybrid-core
+ * @license   http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+namespace Hybrid\Contracts\Container;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class BindingResolutionException extends Exception implements ContainerExceptionInterface {
+	//
+}

--- a/src/Contracts/Container/CircularDependencyException.php
+++ b/src/Contracts/Container/CircularDependencyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hybrid\Contracts\Container;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class CircularDependencyException extends Exception implements ContainerExceptionInterface {
+	//
+}

--- a/src/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Contracts/Container/ContextualBindingBuilder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Hybrid\Contracts\Container;
+
+interface ContextualBindingBuilder {
+
+	/**
+	 * Define the abstract target that depends on the context.
+	 *
+	 * @param  string  $abstract
+	 * @return $this
+	 */
+	public function needs( $abstract );
+
+	/**
+	 * Define the implementation for the contextual binding.
+	 *
+	 * @param  \Closure|string|array  $implementation
+	 * @return void
+	 */
+	public function give( $implementation );
+
+	/**
+	 * Define tagged services to be used as the implementation for the contextual binding.
+	 *
+	 * @param  string  $tag
+	 * @return void
+	 */
+	public function giveTagged( $tag );
+
+	/**
+	 * Specify the configuration item to bind as a primitive.
+	 *
+	 * @param  string  $key
+	 * @param  mixed  $default
+	 * @return void
+	 */
+	public function giveConfig( $key, $default = null );
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Hybrid;
+
+use Closure;
+use ReflectionNamedType;
+
+/**
+ * @internal
+ */
+class Util {
+
+	/**
+	 * If the given value is not an array and not null, wrap it in one.
+	 *
+	 * @param  mixed  $value
+	 * @return array
+	 */
+	public static function arrayWrap( $value ) {
+		if ( is_null( $value ) ) {
+			return [];
+		}
+
+		return is_array( $value ) ? $value : [$value];
+	}
+
+	/**
+	 * Return the default value of the given value.
+	 *
+	 * @param  mixed  $value
+	 * @param  mixed  ...$args
+	 * @return mixed
+	 */
+	public static function unwrapIfClosure( $value, ...$args ) {
+		return $value instanceof Closure ? $value( ...$args ) : $value;
+	}
+
+	/**
+	 * Get the class name of the given parameter's type, if possible.
+	 *
+	 * @param  \ReflectionParameter  $parameter
+	 * @return string|null
+	 */
+	public static function getParameterClassName( $parameter ) {
+		$type = $parameter->getType();
+
+		if ( ! $type instanceof ReflectionNamedType || $type->isBuiltin() ) {
+			return null;
+		}
+
+		$name = $type->getName();
+
+		if ( ! is_null( $class = $parameter->getDeclaringClass() ) ) {
+			if ( $name === 'self' ) {
+				return $class->getName();
+			}
+
+			if ( $name === 'parent' && $parent = $class->getParentClass() ) {
+				return $parent->getName();
+			}
+		}
+
+		return $name;
+	}
+}


### PR DESCRIPTION
- Improve PHP 8 compatibility

- add bound, bindIf, make, singletonIf, scoped, scopedIf, tag, tagged, addContextualBinding, when, factory, getClosure, rebinding, refresh, rebound, getReboundCallbacks, wrap, call, makeWith, resolved, isShared,  isAlias, removeAbstractAlias, getContextualConcrete, findInContextualBindings, isBuildable, hasParameterOverride, getParameterOverride, getLastParameterOverride, resolvePrimitive, resolveClass, resolveVariadicClass, notInstantiable, unresolvablePrimitive, beforeResolving, resolving, afterResolving, fireBeforeResolvingCallbacks, fireBeforeCallbackArray, fireResolvingCallbacks, fireAfterResolvingCallbacks, getCallbacksForType, fireCallbackArray, getBindings, getAlias, getExtenders, forgetExtenders, dropStaleInstances, forgetInstance, forgetInstances, forgetScopedInstances, flush, getInstance, setInstance functions to container
