### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
 		"php": ">=8.0",
 		"psr/container": "1.0.0",
 		"symfony/console": "^5.0 || ^6.0 || ^7.0",
-		"symfony/polyfill-php80": "^1.25.0",
 		"themehybrid/hybrid-contracts": "^2.0",
 		"themehybrid/hybrid-events": "^1.0",
 		"themehybrid/hybrid-filesystem": "^1.0",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: >=8.0`, so the polyfill requirement doesn't seem necessary anymore?